### PR TITLE
Coeff changed from bool to double

### DIFF
--- a/RiotApi.Net.RestClient/Dto/LolStaticData/Generic/SpellVarsDto.cs
+++ b/RiotApi.Net.RestClient/Dto/LolStaticData/Generic/SpellVarsDto.cs
@@ -12,7 +12,7 @@ namespace RiotApi.Net.RestClient.Dto.LolStaticData.Generic
         /// No description available from Riot Documentation
         /// </summary>
         [JsonProperty(PropertyName = "coeff")]
-        public IEnumerable<bool> Coeff { get; set; }
+        public IEnumerable<double> Coeff { get; set; }
 
         /// <summary>
         /// No description available from Riot Documentation


### PR DESCRIPTION
The coeff IEnumerable in the SpellVarsDto was set to deserialize as IEnumerable<bool> which left you with true or false however the API documentation states the Coeff is actually a list<double> and can return values such as 0.25 when I made some requests the check this out.