### PR TITLE
Fixed typographical error.

### DIFF
--- a/RiotApi.Net.RestClient/ApiCalls/LolStaticData.cs
+++ b/RiotApi.Net.RestClient/ApiCalls/LolStaticData.cs
@@ -142,7 +142,7 @@ namespace RiotApi.Net.RestClient.ApiCalls
             }
             if (!string.IsNullOrEmpty(itemListData))
             {
-                apiCallPath += $"&itemListData{itemListData}";
+                apiCallPath += $"&itemListData={itemListData}";
             }
             //make the call
             var dto = MakeCallToRiotApi<ItemListDto>(baseUrl, apiCallPath);


### PR DESCRIPTION
You missed an `=` symbol so the API request generated is malformed.